### PR TITLE
fix(tensor.dart): calloc doesn't release pointer when "tfLiteTensorCopyFromBuffer" throws an error.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@
 Google Inc.
 Paul Ruiz <paultr@gmail.com>
 Saksham Gupta <sakshamg.dev@gmail.com>
+Alexi-Zemcov <alexi.zemcov@gmail.com>

--- a/lib/src/tensor.dart
+++ b/lib/src/tensor.dart
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 import 'dart:ffi';
 import 'dart:typed_data';
 
@@ -23,7 +23,6 @@ import 'package:tflite_flutter/src/util/byte_conversion_utils.dart';
 
 import 'bindings/tensor.dart';
 import 'bindings/types.dart';
-
 import 'ffi/helper.dart';
 import 'quanitzation_params.dart';
 import 'util/list_shape_extension.dart';
@@ -159,9 +158,15 @@ class Tensor {
     checkState(isNotNull(ptr), message: 'unallocated');
     final externalTypedData = ptr.asTypedList(size);
     externalTypedData.setRange(0, bytes.length, bytes);
-    checkState(tfLiteTensorCopyFromBuffer(_tensor, ptr.cast(), bytes.length) ==
-        TfLiteStatus.ok);
-    calloc.free(ptr);
+    try {
+      checkState(
+          tfLiteTensorCopyFromBuffer(_tensor, ptr.cast(), bytes.length) ==
+              TfLiteStatus.ok);
+    } catch (_) {
+      rethrow;
+    } finally {
+      calloc.free(ptr);
+    }
   }
 
   Object copyTo(Object dst) {


### PR DESCRIPTION
While I'm trying to set up my model to make it work, I often get an error at this point. After receiving an error several times in a row, the application crashes. I think it's because calloc doesn't release pointer. So i fixed it.