### PR TITLE
add image package to support image classification and object detection

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   path: ^1.6.2
   quiver: ^3.0.0
   ffi: ^2.0.1
+  image: ^4.0.16
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hi I'm currently working in the image_classification (done) and the object detection (currently) and both use the image package. It will be good to be added into the package to be used globally.