### PR TITLE
expose core ml delegate

### DIFF
--- a/lib/tflite_flutter.dart
+++ b/lib/tflite_flutter.dart
@@ -12,6 +12,7 @@ export 'src/delegate.dart';
 export 'src/delegates/gpu_delegate.dart';
 export 'src/delegates/metal_delegate.dart';
 export 'src/delegates/xnnpack_delegate.dart';
+export 'src/delegates/coreml_delegate.dart';
 export 'src/interpreter.dart';
 export 'src/interpreter_options.dart';
 export 'src/isolate_interpreter.dart';


### PR DESCRIPTION
This is a simple fix to be able to access the core ml delegate functionality of the package.