### PR TITLE
fix: use default coreml options to avoid segfault

### DIFF
--- a/ios/tflite_flutter.podspec
+++ b/ios/tflite_flutter.podspec
@@ -25,6 +25,7 @@ TensorFlow Lite plugin for Flutter apps.
   tflite_version = '2.12.0'
   s.dependency 'TensorFlowLiteSwift', tflite_version
   s.dependency 'TensorFlowLiteSwift/Metal', tflite_version
+  s.dependency 'TensorFlowLiteSwift/CoreML', tflite_version
 
   s.platform = :ios, '11.0'
   s.static_framework = true

--- a/lib/src/delegates/coreml_delegate.dart
+++ b/lib/src/delegates/coreml_delegate.dart
@@ -32,13 +32,11 @@ class CoreMlDelegate implements Delegate {
   CoreMlDelegate._(this._delegate);
 
   factory CoreMlDelegate({CoreMlDelegateOptions? options}) {
-    if (options == null) {
-      return CoreMlDelegate._(
-        tfliteBinding.TfLiteCoreMlDelegateCreate(nullptr),
-      );
-    }
+    final delegateOptions = options ?? CoreMlDelegateOptions();
+
     return CoreMlDelegate._(
-        tfliteBinding.TfLiteCoreMlDelegateCreate(options.base));
+      tfliteBinding.TfLiteCoreMlDelegateCreate(delegateOptions.base),
+    );
   }
 
   @override


### PR DESCRIPTION
Hi, while playing around with the library, I came across a couple of issues:

1. The iOS library spec didn't include CoreML dynamic library. As a result, I had to include it in the original spec.
2. Initiating a CoreML delegate led to a segmentation fault error – find more details below.

The second problem comes from the [TfLiteCoreMlDelegateCreate](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/delegates/coreml/coreml_delegate.mm#LL313C1-L328C2) function, which dereferences an option pointer while assessing if the device is compatible with CoreML delegation:

```c++
...
    if (options->enabled_devices == TfLiteCoreMlDelegateDevicesWithNeuralEngine &&
        !IsNeuralEngineAvailable()) {
      NSLog(@"This device does not have Neural Engine, so Core ML delegate will not be enabled. "
             "If you want to run Core ML delegate anyway, set enabled_devices option to "
             "TfLiteCoreMlDelegateAllDevices (or enabledDevices to .allDevices in Swift).");
      return nullptr;
    }
...
```

Thus, passing a null pointer triggers the following runtime error:

```
* thread #9, name = 'io.flutter.1.ui', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x00000001031e0eb8 Runner`TfLiteCoreMlDelegateCreate + 64
Runner`TfLiteCoreMlDelegateCreate:
->  0x1031e0eb8 <+64>: ldr    w8, [x20]
    0x1031e0ebc <+68>: cbz    w8, 0x1031e0f1c           ; <+164>
    0x1031e0ec0 <+72>: mov    w0, #0x48
    0x1031e0ec4 <+76>: bl     0x10341544c               ; symbol stub for: operator new(unsigned long)
```

Given that this is an issue within the original TensorFlow codebase, we can bypass it by passing default CoreML delegate options, which is precisely what this PR does.

---

As a side note, do you believe I should open a PR to address this issue directly in the TensorFlow repository?