### PR TITLE
fixed equality check for list

### DIFF
--- a/lib/src/tensor.dart
+++ b/lib/src/tensor.dart
@@ -22,6 +22,7 @@ import 'package:quiver/check.dart';
 import 'package:tflite_flutter/src/bindings/bindings.dart';
 import 'package:tflite_flutter/src/bindings/tensorflow_lite_bindings_generated.dart';
 import 'package:tflite_flutter/src/util/byte_conversion_utils.dart';
+import 'package:flutter/foundation.dart';
 
 import 'ffi/helper.dart';
 import 'quanitzation_params.dart';
@@ -246,9 +247,10 @@ class Tensor {
     }
 
     final inputShape = computeShapeOf(input);
-    if (inputShape == shape) {
+    if (listEquals(inputShape, shape)) {
       return null;
     }
+    
     return inputShape;
   }
 


### PR DESCRIPTION
I noticed `runInference` is slower than I expected so I delved deep into the code and found that `resizeInputTensor` was called every time I call `runInference`. This could result in very poor performance like processing live stream of images.

The bug was that it was using incorrect code for comparing list objects.

We should use `listEquals` instead of `==`.
