### PR TITLE
Added namespace in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,7 @@ android {
     // Bumping the plugin compileSdkVersion requires all clients of this plugin
     // to bump the version in their app.
     compileSdkVersion 31
+    namespace 'org.tensorflow.tflite_flutter'
 
     // Bumping the plugin ndkVersion requires all clients of this plugin to bump
     // the version in their app and to download a newer version of the NDK.


### PR DESCRIPTION
**Applies to Android Only**

Added namespace in module's build.gradle file to avoid "Namespace not specified. Specify a namespace in the module's build file." error. New version of Gradle requires namespace to be specified in build.gradle file.

Below is the error I was getting. But after adding namespace manually in package's build.gradle file, it fixed the issue.

![image](https://github.com/tensorflow/flutter-tflite/assets/49032425/3fabda8a-27f8-4a14-8509-8276c39634ba)
