### PR TITLE
Handle SendPort initialization

### DIFF
--- a/lib/src/isolate_interpreter.dart
+++ b/lib/src/isolate_interpreter.dart
@@ -73,7 +73,7 @@ class IsolateInterpreter {
       debugName: debugName,
     );
     final Completer<SendPort> sendPortCompleter = Completer<SendPort>();
-    
+
     _stateSubscription = _receivePort.listen((state) {
       if (state is SendPort) {
         _sendPort = state;
@@ -84,7 +84,7 @@ class IsolateInterpreter {
         _state = state;
       }
     });
-    
+
     await sendPortCompleter.future;
   }
 

--- a/lib/src/isolate_interpreter.dart
+++ b/lib/src/isolate_interpreter.dart
@@ -72,16 +72,20 @@ class IsolateInterpreter {
       _receivePort.sendPort,
       debugName: debugName,
     );
-
+    final Completer<SendPort> sendPortCompleter = Completer<SendPort>();
+    
     _stateSubscription = _receivePort.listen((state) {
       if (state is SendPort) {
         _sendPort = state;
+        sendPortCompleter.complete(_sendPort);
       }
 
       if (state is IsolateInterpreterState) {
         _state = state;
       }
     });
+    
+    await sendPortCompleter.future;
   }
 
   // Main function for the spawned isolate.


### PR DESCRIPTION
Use a Completer to await the initial SendPort reception. This change ensures proper initialization of the SendPort before performing inference.

IMO closes the issue https://github.com/tensorflow/flutter-tflite/issues/126
