### PR TITLE
fix compatibility with latest 'stable' flutter build + bump min sdk to 3.3.0

### DIFF
--- a/example/image_classification_mobilenet/pubspec.yaml
+++ b/example/image_classification_mobilenet/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   camera: ^0.10.5+2

--- a/example/reinforcement_learning/pubspec.yaml
+++ b/example/reinforcement_learning/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/example/style_transfer/pubspec.yaml
+++ b/example/style_transfer/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/example/super_resolution_esrgan/pubspec.yaml
+++ b/example/super_resolution_esrgan/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/example/text_classification/pubspec.yaml
+++ b/example/text_classification/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/lib/src/tensor.dart
+++ b/lib/src/tensor.dart
@@ -55,8 +55,9 @@ class Tensor {
   /// Underlying data buffer as bytes.
   Uint8List get data {
     final data = cast<Uint8>(tfliteBinding.TfLiteTensorData(_tensor));
-    return data.asTypedList(tfliteBinding.TfLiteTensorByteSize(_tensor))
-      .asUnmodifiableView();
+    return data
+        .asTypedList(tfliteBinding.TfLiteTensorByteSize(_tensor))
+        .asUnmodifiableView();
   }
 
   /// Quantization Params associated with the model, [only Android]

--- a/lib/src/tensor.dart
+++ b/lib/src/tensor.dart
@@ -55,8 +55,8 @@ class Tensor {
   /// Underlying data buffer as bytes.
   Uint8List get data {
     final data = cast<Uint8>(tfliteBinding.TfLiteTensorData(_tensor));
-    return UnmodifiableUint8ListView(
-        data.asTypedList(tfliteBinding.TfLiteTensorByteSize(_tensor)));
+    return data.asTypedList(tfliteBinding.TfLiteTensorByteSize(_tensor))
+      .asUnmodifiableView();
   }
 
   /// Quantization Params associated with the model, [only Android]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ version: 0.10.3
 homepage: https://github.com/tensorflow/flutter-tflite
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
   flutter: '>=1.10.0'
 
 dependencies:


### PR DESCRIPTION
The latest Flutter Version broke this package (see #232). This PR restores functionality with the downside of bumping the minimum dart sdk to 3.3.0.

If that is too harsh and there is a better solution, feel free to decline, I won't mind :) 