### PR TITLE
Upgrades dependencies and fix generated bindings

### DIFF
--- a/lib/src/bindings/tensorflow_lite_bindings_generated.dart
+++ b/lib/src/bindings/tensorflow_lite_bindings_generated.dart
@@ -2057,12 +2057,12 @@ class TensorFlowLiteBindings {
       .asFunction<void Function(ffi.Pointer<TfLiteDelegate>)>();
 }
 
-class TfLiteModel extends ffi.Opaque {}
+final class TfLiteModel extends ffi.Opaque {}
 
-class TfLiteInterpreterOptions extends ffi.Opaque {}
+final class TfLiteInterpreterOptions extends ffi.Opaque {}
 
 /// WARNING: This is an experimental interface that is subject to change.
-class TfLiteDelegate extends ffi.Struct {
+final class TfLiteDelegate extends ffi.Struct {
   /// Data that delegate needs to identify itself. This data is owned by the
   /// delegate. The delegate is owned in the user code, so the delegate is
   /// responsible for deallocating this when it is destroyed.
@@ -2171,7 +2171,7 @@ abstract class TfLiteStatus {
 
 /// Forward declare so dependent structs and methods can reference these types
 /// prior to the struct definitions.
-class TfLiteContext extends ffi.Struct {
+final class TfLiteContext extends ffi.Struct {
   /// Number of tensors in the context.
   @ffi.Size()
   external int tensors_size;
@@ -2418,9 +2418,9 @@ class TfLiteContext extends ffi.Struct {
 
 /// Fixed size list of integers. Used for dimensions and inputs/outputs tensor
 /// indices
-class TfLiteIntArray extends ffi.Opaque {}
+final class TfLiteIntArray extends ffi.Opaque {}
 
-class TfLiteTensor extends ffi.Struct {
+final class TfLiteTensor extends ffi.Struct {
   /// The data type specification for data stored in `data`. This affects
   /// what member of `data` union should be used.
   @ffi.Int32()
@@ -2521,7 +2521,7 @@ abstract class TfLiteType {
 }
 
 /// A union of pointers that points to memory for a given tensor.
-class TfLitePtrUnion extends ffi.Union {
+final class TfLitePtrUnion extends ffi.Union {
   /// Do not access these members directly, if possible, use
   /// GetTensorData<TYPE>(tensor) instead, otherwise only access .data, as other
   /// members are deprecated.
@@ -2562,13 +2562,13 @@ class TfLitePtrUnion extends ffi.Union {
 }
 
 /// Half precision data type compatible with the C99 definition.
-class TfLiteFloat16 extends ffi.Struct {
+final class TfLiteFloat16 extends ffi.Struct {
   @ffi.Uint16()
   external int data;
 }
 
 /// Single-precision complex data type compatible with the C99 definition.
-class TfLiteComplex64 extends ffi.Struct {
+final class TfLiteComplex64 extends ffi.Struct {
   /// real and imaginary parts, respectively.
   @ffi.Float()
   external double re;
@@ -2578,7 +2578,7 @@ class TfLiteComplex64 extends ffi.Struct {
 }
 
 /// Double-precision complex data type compatible with the C99 definition.
-class TfLiteComplex128 extends ffi.Struct {
+final class TfLiteComplex128 extends ffi.Struct {
   /// real and imaginary parts, respectively.
   @ffi.Double()
   external double re;
@@ -2593,7 +2593,7 @@ class TfLiteComplex128 extends ffi.Struct {
 /// Parameters for asymmetric quantization. Quantized values can be converted
 /// back to float using:
 /// real_value = scale * (quantized_value - zero_point)
-class TfLiteQuantizationParams extends ffi.Struct {
+final class TfLiteQuantizationParams extends ffi.Struct {
   @ffi.Float()
   external double scale;
 
@@ -2626,9 +2626,10 @@ abstract class TfLiteAllocationType {
 /// The delegates should use zero or positive integers to represent handles.
 /// -1 is reserved from unallocated status.
 typedef TfLiteBufferHandle = ffi.Int;
+typedef DartTfLiteBufferHandle = int;
 
 /// Structure specifying the quantization used by the tensor, if-any.
-class TfLiteQuantization extends ffi.Struct {
+final class TfLiteQuantization extends ffi.Struct {
   /// The type of quantization held by params.
   @ffi.Int32()
   external int type;
@@ -2651,7 +2652,7 @@ abstract class TfLiteQuantizationType {
 
 /// Parameters used to encode a sparse tensor. For detailed explanation of each
 /// field please refer to lite/schema/schema.fbs.
-class TfLiteSparsity extends ffi.Struct {
+final class TfLiteSparsity extends ffi.Struct {
   external ffi.Pointer<TfLiteIntArray> traversal_order;
 
   external ffi.Pointer<TfLiteIntArray> block_map;
@@ -2663,7 +2664,7 @@ class TfLiteSparsity extends ffi.Struct {
 }
 
 /// Metadata to encode each dimension in a sparse tensor.
-class TfLiteDimensionMetadata extends ffi.Struct {
+final class TfLiteDimensionMetadata extends ffi.Struct {
   @ffi.Int32()
   external int format;
 
@@ -2684,7 +2685,7 @@ abstract class TfLiteDimensionType {
 /// A structure representing an instance of a node.
 /// This structure only exhibits the inputs, outputs, user defined data and some
 /// node properties (like statefulness), not other features like the type.
-class TfLiteNode extends ffi.Struct {
+final class TfLiteNode extends ffi.Struct {
   /// Inputs to this node expressed as indices into the simulator's tensors.
   external ffi.Pointer<TfLiteIntArray> inputs;
 
@@ -2724,7 +2725,7 @@ class TfLiteNode extends ffi.Struct {
   external bool might_have_side_effect;
 }
 
-class TfLiteRegistration extends ffi.Struct {
+final class TfLiteRegistration extends ffi.Struct {
   /// Initializes the op from serialized data.
   /// Called only *once* for the lifetime of the op, so any one-time allocations
   /// should be made here (unless they depend on tensor sizes).
@@ -2810,14 +2811,14 @@ class TfLiteRegistration extends ffi.Struct {
   external ffi.Pointer<TfLiteRegistrationExternal> registration_external;
 }
 
-class TfLiteRegistrationExternal extends ffi.Opaque {}
+final class TfLiteRegistrationExternal extends ffi.Opaque {}
 
 /// An external context is a collection of information unrelated to the TF Lite
 /// framework, but useful to a subset of the ops. TF Lite knows very little
 /// about the actual contexts, but it keeps a list of them, and is able to
 /// refresh them if configurations like the number of recommended threads
 /// change.
-class TfLiteExternalContext extends ffi.Struct {
+final class TfLiteExternalContext extends ffi.Struct {
   @ffi.Int32()
   external int type;
 
@@ -2852,7 +2853,7 @@ abstract class TfLiteExternalContextType {
 /// `TfLiteNode` of the delegate node.
 ///
 /// See also the `CreateDelegateParams` function in `interpreter.cc` details.
-class TfLiteDelegateParams extends ffi.Struct {
+final class TfLiteDelegateParams extends ffi.Struct {
   external ffi.Pointer<TfLiteDelegate> delegate;
 
   external ffi.Pointer<TfLiteIntArray> nodes_to_replace;
@@ -2866,7 +2867,7 @@ class TfLiteDelegateParams extends ffi.Struct {
 /// of information required for a kernel to run during TfLiteRegistration::Eval.
 /// TODO(b/160955687): Move this field into TF_LITE_STATIC_MEMORY when TFLM
 /// builds with this flag by default internally.
-class TfLiteEvalTensor extends ffi.Struct {
+final class TfLiteEvalTensor extends ffi.Struct {
   /// A union of data pointers. The appropriate type should be used for a typed
   /// tensor based on `type`.
   external TfLitePtrUnion data;
@@ -2891,7 +2892,7 @@ class TfLiteEvalTensor extends ffi.Struct {
 /// the same as with `TfLiteDelegate`.
 ///
 /// WARNING: This is an experimental interface that is subject to change.
-class TfLiteOpaqueDelegateBuilder extends ffi.Struct {
+final class TfLiteOpaqueDelegateBuilder extends ffi.Struct {
   /// Data that delegate needs to identify itself. This data is owned by the
   /// delegate. The delegate is owned in the user code, so the delegate is
   /// responsible for deallocating this when it is destroyed.
@@ -2939,13 +2940,13 @@ class TfLiteOpaqueDelegateBuilder extends ffi.Struct {
   external int flags;
 }
 
-class TfLiteOpaqueContext extends ffi.Opaque {}
+final class TfLiteOpaqueContext extends ffi.Opaque {}
 
-class TfLiteOpaqueDelegateStruct extends ffi.Opaque {}
+final class TfLiteOpaqueDelegateStruct extends ffi.Opaque {}
 
-class TfLiteOpaqueTensor extends ffi.Opaque {}
+final class TfLiteOpaqueTensor extends ffi.Opaque {}
 
-class TfLiteInterpreter extends ffi.Opaque {}
+final class TfLiteInterpreter extends ffi.Opaque {}
 
 /// The enum for builtin operators.
 /// Note: CUSTOM, DELEGATE, and PLACEHOLDER_FOR_GREATER_OP_CODES are 3 special
@@ -3112,18 +3113,18 @@ abstract class TfLiteBuiltinOperator {
   static const int kTfLiteBuiltinSign = 158;
 }
 
-class TfLiteOpaqueNode extends ffi.Opaque {}
+final class TfLiteOpaqueNode extends ffi.Opaque {}
 
 typedef va_list = __builtin_va_list;
 typedef __builtin_va_list = ffi.Pointer<ffi.Char>;
 
-class TfLiteSignatureRunner extends ffi.Opaque {}
+final class TfLiteSignatureRunner extends ffi.Opaque {}
 
 /// Old version of `TfLiteRegistration` to maintain binary backward
 /// compatibility.
 /// WARNING: This structure is deprecated / not an official part of the API.
 /// It should be only used for binary backward compatibility.
-class TfLiteRegistration_V1 extends ffi.Struct {
+final class TfLiteRegistration_V1 extends ffi.Struct {
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<ffi.Void> Function(ffi.Pointer<TfLiteContext> context,
@@ -3167,7 +3168,7 @@ abstract class TfLiteCoreMlDelegateEnabledDevices {
   static const int TfLiteCoreMlDelegateAllDevices = 1;
 }
 
-class TfLiteCoreMlDelegateOptions extends ffi.Struct {
+final class TfLiteCoreMlDelegateOptions extends ffi.Struct {
   /// Only create delegate when Neural Engine is available on the device.
   @ffi.Int32()
   external int enabled_devices;
@@ -3211,7 +3212,7 @@ abstract class TFLGpuDelegateWaitType {
 
 /// Creates a new delegate instance that need to be destroyed with
 /// DeleteFlowDelegate when delegate is no longer used by tflite.
-class TFLGpuDelegateOptions extends ffi.Struct {
+final class TFLGpuDelegateOptions extends ffi.Struct {
   /// Allows to quantify tensors, downcast values, process in float16 etc.
   @ffi.Bool()
   external bool allow_precision_loss;
@@ -3224,9 +3225,9 @@ class TFLGpuDelegateOptions extends ffi.Struct {
   external bool enable_quantization;
 }
 
-class TfLiteXNNPackDelegateWeightsCache extends ffi.Opaque {}
+final class TfLiteXNNPackDelegateWeightsCache extends ffi.Opaque {}
 
-class TfLiteXNNPackDelegateOptions extends ffi.Struct {
+final class TfLiteXNNPackDelegateOptions extends ffi.Struct {
   /// Number of threads to use in the thread pool.
   /// 0 or negative value means no thread pool used.
   @ffi.Int32()
@@ -3300,7 +3301,7 @@ abstract class TfLiteGpuExperimentalFlags {
 /// IMPORTANT: Always use TfLiteGpuDelegateOptionsV2Default() method to create
 /// new instance of TfLiteGpuDelegateOptionsV2, otherwise every new added option
 /// may break inference.
-class TfLiteGpuDelegateOptionsV2 extends ffi.Struct {
+final class TfLiteGpuDelegateOptionsV2 extends ffi.Struct {
   /// When set to zero, computations are carried out in maximal possible
   /// precision. Otherwise, the GPU may quantify tensors, downcast values,
   /// process in FP16 to increase performance. For most models precision loss is

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   ffi: ^2.0.1
 
 dev_dependencies:
-  ffigen: ^7.2.11
+  ffigen: ^8.0.0
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,14 +29,14 @@ dependencies:
   path: ^1.6.2
   plugin_platform_interface: ^2.0.2
   quiver: ^3.0.0
-  ffi: ^2.0.1
+  ffi: ^2.1.3
 
 dev_dependencies:
-  ffigen: ^8.0.0
+  ffigen: ^12.0.0
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  melos: ^3.1.0
+  melos: ^6.1.0
   test: ^1.6.4
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
Fix #234 
Upgraded ffigen to `12.0.0` ffi to `2.1.3` and melos to `6.1.0`. Upgraded melos due to dependencies conflicts.
ffigen `13.0.0` is the latest, but the generated bindings produced a lot of errors that requires deep understanding of the lib to fix safely.
Also, Since `11.0.0`:
> Any compiler errors/warnings in source header files will now result in bindings to not be generated by default, since it may result in invalid bindings if the compiler makes a wrong guess. A flag --ignore-source-errors (or yaml config ignore-source-errors: true) must be passed to change this behaviour.

I was getting this error before and after upgrading, so I bypassed it with `--ignore-source-errors`:
```
[SEVERE] : Header ./src/tensorflow_lite/metal_delegate.h: Total errors/warnings: 2.
[SEVERE] :     ./src/tensorflow_lite/metal_delegate.h:81:49: error: unknown type name 'id' [Semantic Issue]
[SEVERE] :     ./src/tensorflow_lite/metal_delegate.h:81:51: error: expected ')' [Parse Issue]
``` 

I don't know if this error is specific to me because I don't have Metal libs installed, but it wasn't caused by the upgrade. Beside, the library tests are passing, and I tested it with my app, it is also working as expected.