### PR TITLE
Update interpreter.dart

### DIFF
--- a/lib/src/interpreter.dart
+++ b/lib/src/interpreter.dart
@@ -210,10 +210,10 @@ class Interpreter {
       inputTensors.elementAt(i).setTo(inputs[i]);
     }
 
-    var inferenceStartNanos = DateTime.now().microsecondsSinceEpoch;
+    var inferenceStartMicros = DateTime.now().microsecondsSinceEpoch;
     invoke();
     _lastNativeInferenceDurationMicroSeconds =
-        DateTime.now().microsecondsSinceEpoch - inferenceStartNanos;
+        DateTime.now().microsecondsSinceEpoch - inferenceStartMicros;
   }
 
   /// Gets all input tensors associated with the model.


### PR DESCRIPTION
Fix variable name to reflect microseconds for _lastNativeInferenceDurationMicroSeconds