### PR TITLE
docs(readme): replace pub.dartlang.org with pub.dev; normalize macOS; update Flutter docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
      <img src="https://img.shields.io/badge/Platform-Flutter-02569B?logo=flutter"
        alt="Platform" />
    </a>
-   <a href="https://pub.dartlang.org/packages/tflite_flutter">
+   <a href="https://pub.dev/packages/tflite_flutter">
      <img src="https://img.shields.io/pub/v/tflite_flutter.svg"
        alt="Pub Package" />
    </a>
@@ -71,9 +71,9 @@ When creating a release archive (IPA), the symbols are stripped by Xcode, so the
 1. In Xcode, go to **Target Runner > Build Settings > Strip Style**
 2. Change from **All Symbols** to **Non-Global Symbols**
 
-### MacOS
+### macOS
 
-For MacOS a TensorFlow Lite dynamic library needs to be added to the project manually.
+For macOS a TensorFlow Lite dynamic library needs to be added to the project manually.
 For this, first a `.dylib` needs to be built. You can follow the [Bazel build guide](https://www.tensorflow.org/lite/guide/build_arm) or the [CMake build guide](https://www.tensorflow.org/lite/guide/build_cmake) to build the libraries.
 
 **CMake Note:**


### PR DESCRIPTION
Small documentation cleanup in README:
- Replace legacy `pub.dartlang.org` links with `pub.dev`
- Normalize platform spelling `MacOS` -> `macOS`
- Update `flutter.dev/docs/...` links to `docs.flutter.dev/...`

No code changes.