### PR TITLE
migrate from TensorFlow Lite to LiteRT for 16 KB page size support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ example/object_detection_ssd_mobilenet/assets/models/ssd_mobilenet.tflite
 **/assets/models/**
 **/assets/models/!README
 **/assets/models/.gitkeep
+
+# FVM Version Cache
+.fvm/
+.fvmrc

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,8 +50,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     defaultConfig {
@@ -61,8 +61,8 @@ android {
 
 
 dependencies {
-    def tflite_version = "2.11.0"
+    def litert_version = "1.4.0"
     
-    implementation("org.tensorflow:tensorflow-lite:${tflite_version}")
-    implementation("org.tensorflow:tensorflow-lite-gpu:${tflite_version}")
+    implementation("com.google.ai.edge.litert:litert:${litert_version}")
+    implementation("com.google.ai.edge.litert:litert-gpu:${litert_version}")
 }


### PR DESCRIPTION
- Replace org.tensorflow:tensorflow-lite:2.11.0 with com.google.ai.edge.litert:litert:1.4.0 (required for Android 16 KB page size)
- Set sourceCompatibility and targetCompatibility to JavaVersion.VERSION_11 (project-specific requirement)