### PR TITLE
Fix: Replace deprecated withOpacity with withValues

### DIFF
--- a/example/audio_classification/lib/main.dart
+++ b/example/audio_classification/lib/main.dart
@@ -186,7 +186,7 @@ class _MyHomePageState extends State<MyHomePage> {
       backgroundColor: Colors.white,
       appBar: AppBar(
         title: Image.asset('assets/images/tfl_logo.png'),
-        backgroundColor: Colors.black.withOpacity(0.5),
+        backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
       body: _buildBody(),
     );

--- a/example/bertqa/lib/ui/qa_detail.dart
+++ b/example/bertqa/lib/ui/qa_detail.dart
@@ -140,7 +140,7 @@ class _QaDetailState extends State<QaDetail> {
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(color: Colors.white, boxShadow: [
               BoxShadow(
-                  color: Colors.grey.withOpacity(0.5),
+                  color: Colors.grey.withValues(alpha: 0.5),
                   spreadRadius: 2,
                   blurRadius: 5,
                   offset: const Offset(0, 3))

--- a/example/digit_classification/lib/main.dart
+++ b/example/digit_classification/lib/main.dart
@@ -91,7 +91,7 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Center(
           child: Image.asset('assets/images/tfl_logo.png'),
         ),
-        backgroundColor: Colors.black.withOpacity(0.5),
+        backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
       body: Center(
         child: Column(

--- a/example/gesture_classification/lib/main.dart
+++ b/example/gesture_classification/lib/main.dart
@@ -166,7 +166,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
         title: Center(
           child: Image.asset('assets/images/tfl_logo.png'),
         ),
-        backgroundColor: Colors.black.withOpacity(0.5),
+        backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
       body: Center(
           // Center is a layout widget. It takes a single child and positions it

--- a/example/image_classification_mobilenet/lib/main.dart
+++ b/example/image_classification_mobilenet/lib/main.dart
@@ -88,7 +88,7 @@ class _BottomNavigationBarExampleState
     return Scaffold(
       appBar: AppBar(
         title: Image.asset('assets/images/tfl_logo.png'),
-        backgroundColor: Colors.black.withOpacity(0.5),
+        backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
       body: Center(
         child: _widgetOptions?.elementAt(_selectedIndex),

--- a/example/image_segmentation/lib/main.dart
+++ b/example/image_segmentation/lib/main.dart
@@ -226,7 +226,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
                     // parse color from label color
                     color: Color(ImageSegmentationHelper
                             .labelColors[_labelsIndex![index]])
-                        .withOpacity(0.5),
+                        .withValues(alpha: 0.5),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
@@ -251,7 +251,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
         title: Center(
           child: Image.asset('assets/images/tfl_logo.png'),
         ),
-        backgroundColor: Colors.black.withOpacity(0.5),
+        backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
       body: cameraWidget(context),
     );

--- a/example/object_detection_ssd_mobilenet/lib/main.dart
+++ b/example/object_detection_ssd_mobilenet/lib/main.dart
@@ -64,7 +64,7 @@ class _MyHomeState extends State<MyHome> {
     return Scaffold(
       appBar: AppBar(
         title: Image.asset('assets/images/tfl_logo.png'),
-        backgroundColor: Colors.black.withOpacity(0.5),
+        backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
       body: SafeArea(
         child: Column(

--- a/example/object_detection_ssd_mobilenet_v2/lib/main.dart
+++ b/example/object_detection_ssd_mobilenet_v2/lib/main.dart
@@ -49,7 +49,7 @@ class _MyHomeState extends State<MyHome> {
     return Scaffold(
       appBar: AppBar(
         title: Image.asset('assets/images/tfl_logo.png'),
-        backgroundColor: Colors.black.withOpacity(0.5),
+        backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
       body: SafeArea(
         child: Column(

--- a/example/pose_estimation/lib/main.dart
+++ b/example/pose_estimation/lib/main.dart
@@ -180,7 +180,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
         title: Center(
           child: Image.asset('assets/images/tfl_logo.png'),
         ),
-        backgroundColor: Colors.black.withOpacity(0.5),
+        backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
       body: resultWidget(context),
     );

--- a/example/style_transfer/lib/main.dart
+++ b/example/style_transfer/lib/main.dart
@@ -291,7 +291,7 @@ class _HomeState extends State<Home> {
     return Scaffold(
       appBar: AppBar(
         title: Image.asset('assets/images/tfl_logo.png'),
-        backgroundColor: Colors.black.withOpacity(0.5),
+        backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
       body: SafeArea(
         child: Center(

--- a/example/super_resolution_esrgan/lib/main.dart
+++ b/example/super_resolution_esrgan/lib/main.dart
@@ -181,7 +181,7 @@ class _HomeState extends State<Home> {
     return Scaffold(
       appBar: AppBar(
         title: Image.asset('assets/images/tfl_logo.png'),
-        backgroundColor: Colors.black.withOpacity(0.5),
+        backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
       body: SafeArea(
         child: Center(


### PR DESCRIPTION
Fixes CI/CD analyzer warnings from PR #294 by replacing deprecated `withOpacity()` with `withValues(alpha:)`.

  ## Changes
  - Updated 11 example files across all projects
  - Replaced 12 instances of deprecated method
  - Verified with `flutter analyze` - no issues found

  ## Testing
  - All examples analyzed successfully
  - No breaking changes to functionality