### PR TITLE
bump version to 0.12.0 for 16KB page size release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.12.0 (October 27, 2025)
+* Android 16KB page size support for Google Play 2025 compliance
+* Updated Android Gradle Plugin to 8.6.1
+* Updated Compile SDK to 36 (Android 15+)
+* Modernized Gradle build system with plugins DSL
+* Updated Kotlin to 1.8.10
+* Fixed deprecated withOpacity warnings across examples
+* All 14 example projects verified working
+
 ## 0.11.0 (September 3, 2024)
 * FFI update, Dart/Flutter version updates
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: tflite_flutter
 description: TensorFlow Lite Flutter plugin provides an easy, flexible, and fast Dart API to integrate TFLite models in flutter apps across mobile and desktop platforms.
-version: 0.11.0
+version: 0.12.0
 homepage: https://github.com/tensorflow/flutter-tflite
 
 environment:


### PR DESCRIPTION
## Release v0.12.0

  This PR bumps the version to 0.12.0 to prepare for publishing the Android 16KB page size support to pub.dev.

  ### What's New in 0.12.0
  - Android 16KB page size support (Google Play 2025 compliance)
  - Updated Android Gradle Plugin to 8.6.1
  - Updated Compile SDK to 36 (Android 15+)
  - Modernized Gradle build system with plugins DSL
  - Updated Kotlin to 1.8.10
  - Fixed deprecated withOpacity warnings
  - All 14 example projects verified working

  ### Changes in this PR
  - Updated `pubspec.yaml`: version `0.11.0` → `0.12.0`
  - Updated `CHANGELOG.md` with release notes

  ### Merged PRs
  - #294: Android 16KB page size support
  - #297: Fix deprecated withOpacity warnings